### PR TITLE
Making suggestions more modular

### DIFF
--- a/Model/Result.php
+++ b/Model/Result.php
@@ -13,9 +13,9 @@ class Result
 
     protected $exception;
     protected $documentationReferences = [];
-    protected $suggestedSolution = '';
+    protected $suggestedSolutions = [];
     
-    public function setException(\Exception $exception)
+    public function __construct(\Exception $exception)
     {
         $this->exception = $exception;
     }
@@ -38,13 +38,13 @@ class Result
         return $this->documentationReferences;
     }
     
-    public function setSuggestedSolution($solution)
+    public function addSuggestedSolution($solution)
     {
-        $this->suggestedSolution = $solution;
+        $this->suggestedSolutions[] = $solution;
     }
     
-    public function getSuggestedSolution()
+    public function getSuggestedSolutions()
     {
-        return $this->suggestedSolution;
+        return $this->suggestedSolutions;
     }
 }

--- a/Model/Suggestion/BadMethodCall/MissingRequired.php
+++ b/Model/Suggestion/BadMethodCall/MissingRequired.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ */
+
+namespace Cotya\Debug\Model\Suggestion\BadMethodCall;
+
+use Cotya\Debug\Model\Result;
+use Cotya\Debug\Model\SuggestionInterface;
+
+class MissingRequired implements SuggestionInterface
+{
+
+    public function match(\Exception $exception)
+    {
+        return ($exception instanceof \BadMethodCallException
+            && preg_match('/Missing required argument (\$.*?) of (.*)\./', $exception->getMessage())
+        );
+    }
+
+    public function process(Result $result)
+    {
+        $result->addDocumentationReference(
+            '<a href="http://devdocs.magento.com/guides/v1.0/extension-dev-guide/depend-inj.html">Dependency Injection</a>'
+        );
+
+        $matches = [];
+        preg_match('/Missing required argument (\$.*?) of (.*)\./', $result->getException()->getMessage(), $matches);
+        $className = $matches[2];
+        $argumentName = $matches[1];
+        $result->addSuggestedSolution("You may need to inject a value for $argumentName into $className via di.xml configuration.");
+    }
+}

--- a/Model/Suggestion/ClassDoesNotExist.php
+++ b/Model/Suggestion/ClassDoesNotExist.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ */
+
+namespace Cotya\Debug\Model\Suggestion;
+
+use Cotya\Debug\Model\Result;
+use Cotya\Debug\Model\SuggestionInterface;
+
+class ClassDoesNotExist implements SuggestionInterface
+{
+
+    public function match(\Exception $exception)
+    {
+        return preg_match('/Class .* does not exist/', $exception->getMessage());
+    }
+
+    public function process(Result $result)
+    {
+        $result->addSuggestedSolution("The class could have been moved and there is an outdated reference.  Try
+            clearing the 'var/generation' and 'var/cache' directories.
+");
+
+    }
+}

--- a/Model/Suggestion/IntervalNotFound.php
+++ b/Model/Suggestion/IntervalNotFound.php
@@ -1,42 +1,22 @@
 <?php
 /**
- *
- *
- *
- *
  */
 
-namespace Cotya\Debug\Traits;
+namespace Cotya\Debug\Model\Suggestion;
 
 use Cotya\Debug\Model\Result;
+use Cotya\Debug\Model\SuggestionInterface;
 
-trait Handler
+class IntervalNotFound implements SuggestionInterface
 {
 
-
-    /**
-     * @param \Exception $exception
-     *
-     * @return Result
-     */
-    protected function processException(\Exception $exception)
+    public function match(\Exception $exception)
     {
-        $result = new Result();
-        $result->setException($exception);
-        if (strpos($exception->getMessage(), 'Interval not found by config') === 0) {
-            $this->processIntervalNotFoundByConfig($result);
-        }
-        
-        return $result;
+        return (strpos($exception->getMessage(), 'Interval not found by config') === 0);
     }
 
-    protected function processIntervalNotFoundByConfig(Result $result)
+    public function process(Result $result)
     {
-        $result->addDocumentationReference('there is no official documentation directly related to this,
-         please help extending it by contributing to https://github.com/magento/devdocs');
-        
-
-        
         $trace = $result->getException()->getTrace();
         if ($trace[0]['class'] == 'Magento\Framework\Search\Dynamic\IntervalFactory') {
             $missedIntervalName = str_replace(
@@ -53,8 +33,8 @@ trait Handler
             $codeExample = <<<XML
 <type name="Magento\Framework\Search\Dynamic\IntervalFactory">
     <arguments>
-        <!-- 
-        this usually is of type "const" with a reference to a php constant, 
+        <!--
+        this usually is of type "const" with a reference to a php constant,
         but we cant resolve this automagically yet
         -->
         <argument name="configPath" xsi:type="string">{$trace[0]['args'][2]}</argument>
@@ -66,13 +46,12 @@ trait Handler
 </type>
 XML;
             $codeExample = htmlspecialchars($codeExample);
-            $result->setSuggestedSolution("you are missing an Interval definition for one of your classes.
+            $result->addSuggestedSolution("you are missing an Interval definition for one of your classes.
 You need to extend your module di.xml to solve this. The needed code should look similar to this:
 <pre style='border: 1px dotted;padding:5px;'>
 $codeExample
 </pre>
             ");
         }
-        //var_dump($trace[0]['args']);
     }
 }

--- a/Model/SuggestionInterface.php
+++ b/Model/SuggestionInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ */
+
+namespace Cotya\Debug\Model;
+
+interface SuggestionInterface
+{
+    /**
+     * Checks if this suggestion is a match for the exception.
+     *
+     * @param \Exception $exception
+     * @return boolean Returns true if a suggestion can be offered for this exception
+     */
+    public function match(\Exception $exception);
+
+    /**
+     * Injects suggestion information into the Result.
+     *
+     * @param Result $result
+     * @return void
+     */
+    public function process(Result $result);
+}

--- a/Model/Suggestions.php
+++ b/Model/Suggestions.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ *
+ */
+
+namespace Cotya\Debug\Model;
+
+class Suggestions
+{
+    /**
+     * @var string[] List of class names that implement SuggestionInterface
+     */
+    private $classes;
+
+    private $suggestions = null;
+
+    /**
+     * @param string[] $classes
+     */
+    public function __construct($classes)
+    {
+        $this->classes = $classes;
+    }
+
+    /**
+     * @return SuggestionInterface[]
+     */
+    public function getSuggestions()
+    {
+        if (null === $this->suggestions) {
+            $this->suggestions = [];
+            foreach($this->classes as $className) {
+                // trim is needed to allow for newlines in the di.xml that provides the class names
+                $className = trim($className);
+                /** @var SuggestionInterface $class */
+                $class = new $className();
+                $this->suggestions[] = $class;
+            }
+        }
+        return $this->suggestions;
+    }
+
+    /**
+     * @param \Exception $exception
+     * @return SuggestionInterface[]
+     */
+    public function findMatching(\Exception $exception) {
+        return array_filter($this->getSuggestions(), function(SuggestionInterface $suggestion) use ($exception) {
+                return $suggestion->match($exception);
+        });
+    }
+}

--- a/Plugin/Http.php
+++ b/Plugin/Http.php
@@ -9,18 +9,33 @@
 namespace Cotya\Debug\Plugin;
 
 use Cotya\Debug\Model\Result;
+use Cotya\Debug\Model\Suggestions;
 use Cotya\Debug\Traits\Handler;
 use Magento\Framework\App\Bootstrap;
 use Magento\Framework\HTTP\PhpEnvironment\Response;
 
 class Http
 {
-    use Handler;
-    
+    private $suggestions;
+
+    public function __construct(Suggestions $suggestions)
+    {
+        $this->suggestions = $suggestions;
+    }
     
     public function aroundCatchException($subject, \Closure $proceed, Bootstrap $bootstrap, \Exception $exception)
     {
-        $optimizedResponse = $this->generateOptimizedExceptionResponse($this->processException($exception));
+        $result = new Result($exception);
+        $matchingSuggestions = $this->suggestions->findMatching($exception);
+
+        if (!$matchingSuggestions) {
+            return $proceed($bootstrap, $exception);
+        }
+        foreach ($matchingSuggestions as $suggestion) {
+            $suggestion->process($result);
+        }
+
+        $optimizedResponse = $this->generateOptimizedExceptionResponse($result);
         /**
          * @see \Magento\Framework\App\Http::catchException
          * @see \Magento\Framework\App\Http::handleDeveloperMode
@@ -41,16 +56,25 @@ class Http
         foreach ($result->getDocumentationReferences() as $reference) {
             $documentationReferenceHtml .= "<li>$reference</li>";
         }
+        if (!$documentationReferenceHtml) {
+            $documentationReferenceHtml = 'There is no official documentation directly related to this,
+         please help extending it by contributing to <a href="https://github.com/magento/devdocs">Magento DevDocs</a>';
+        }
         $documentationReferenceHtml = "<ul>$documentationReferenceHtml</ul>";
+
+        $suggestedSolutions = '';
+        foreach ($result->getSuggestedSolutions() as $suggestedSolution) {
+            $suggestedSolutions .= "<li><div>$suggestedSolution</div></li>\n";
+        }
         
         $html = "<html>
         <head></head>
         <body>
-        <h2>optimized Exception Display</h2>
+        <h2>Optimized Exception Display</h2>
         <h3>{$result->getException()->getMessage()}</h3>
         $documentationReferenceHtml
-        <h4>suggested solution:</h4>
-        <div>{$result->getSuggestedSolution()}</div>
+        <h4>Suggested solutions:</h4>
+        <div><ul>$suggestedSolutions</ul></div>
         <h4>Exception trace:</h4>
         <pre>{$result->getException()->getTraceAsString()}</pre>
         </body></html>";

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "cotya/module-debug",
+  "description": "Magento Module to improve the output of exceptions",
+  "require": {
+    "php": "~5.5.0|~5.6.0",
+    "magento/framework": "~0.42.0",
+    "magento/magento-composer-installer": "*"
+  },
+  "minimum-stability": "beta",
+  "type": "magento2-module",
+  "extra": {
+    "map": [
+      [
+        "*",
+        "Cotya/Debug"
+      ]
+    ]
+  }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -8,4 +8,16 @@
     <type name="Magento\Framework\App\Http">
         <plugin name="Cotya_Debug_Plugin_Http" type="Cotya\Debug\Plugin\Http"/>
     </type>
+    <type name="Cotya\Debug\Model\Suggestions">
+        <arguments>
+            <argument name="classes" xsi:type="array">
+                <item name="Cotya_IntervalNotFound" xsi:type="string">
+                    Cotya\Debug\Model\Suggestion\IntervalNotFound</item>
+                <item name="Cotya_ClassDoesNotExist" xsi:type="string">
+                    Cotya\Debug\Model\Suggestion\ClassDoesNotExist</item>
+                <item name="Cotya_BadMethodCall_MissingRequired" xsi:type="string">
+                    Cotya\Debug\Model\Suggestion\BadMethodCall\MissingRequired</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -4,9 +4,6 @@
         xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd"
         >
     <module name="Cotya_Debug" schema_version="0.1.0.0" >
-        <sequence>
-            
-        </sequence>
     </module>
     
 </config>


### PR DESCRIPTION
- Inject suggestion processors via `di.xml` instead of traits. 
- Allow multiple matches for the same exception, where each match can add its own suggestion.
- Provides a default message when no documentation reference is provided.
- Adds two new exception suggestions
